### PR TITLE
fix: Allow apt-get upgrade to be fully non-interactive

### DIFF
--- a/pg_config.sh
+++ b/pg_config.sh
@@ -1,5 +1,5 @@
 apt-get -qqy update
-apt-get -qqy upgrade
+DEBIAN_FRONTEND=noninteractive apt-get -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" upgrade
 apt-get -qqy install postgresql python-psycopg2
 apt-get -qqy install python-sqlalchemy
 apt-get -qqy install python-pip


### PR DESCRIPTION
This is the same change that was made to the main FSND
repository and stops the provisioning script from stopping
waiting for user input (which is not possible when running
`vagrant up`) when upgrading GRUB bootloader.

Resolves: #8