### PR TITLE
Fix PIP install errs.

### DIFF
--- a/pg_config.sh
+++ b/pg_config.sh
@@ -4,9 +4,9 @@ apt-get -qqy install postgresql python-psycopg2
 apt-get -qqy install python-sqlalchemy
 apt-get -qqy install python-pip
 pip install --upgrade pip
-pip install werkzeug==0.8.3
-pip install flask==0.9
-pip install Flask-Login==0.1.3
-pip install oauth2client
-pip install requests
-pip install httplib2
+pip2 install werkzeug==0.8.3
+pip2 install flask==0.9
+pip2 install Flask-Login==0.1.3
+pip2 install oauth2client
+pip2 install requests
+pip2 install httplib2


### PR DESCRIPTION
Please see https://discussions.udacity.com/t/pip-install-error-during-vagrant-up-on-macos/668380

In a nutshell, pip is failing to install packages for the version of python installed on the box. By adjusting the command from pip to pip2 they install successfully.

pip2 install werkzeug==0.8.3
pip2 install flask==0.9
pip2 install Flask-Login==0.1.3
pip2 install oauth2client
pip2 install requests
pip2 install httplib2
