### PR TITLE
fix: Make the db connection shared across multiple threads

### DIFF
--- a/project.py
+++ b/project.py
@@ -7,7 +7,7 @@ from database_setup import Base, Restaurant, MenuItem
 
 
 #Connect to Database and create database session
-engine = create_engine('sqlite:///restaurantmenu.db')
+engine = create_engine('sqlite:///restaurantmenu.db' + '?check_same_thread=False')
 Base.metadata.bind = engine
 
 DBSession = sessionmaker(bind=engine)


### PR DESCRIPTION
Hey, 
When running the app on [localhost](http://localhost:5000/ ), It sometimes does not work and showing the following error:

```
sqlalchemy.exc.ProgrammingError
ProgrammingError: (sqlite3.ProgrammingError) SQLite objects created in a thread can only be used in that same thread.The object was created in thread id -1245000896 and this is thread id -1255146688 [SQL: u'SELECT restaurant.id AS restaurant_id, restaurant.name AS restaurant_name \nFROM restaurant ORDER BY restaurant.name ASC'] [parameters: [immutabledict({})]]


Traceback (most recent call last)
File "/usr/local/lib/python2.7/dist-packages/flask/app.py", line 2309, in __call__
return self.wsgi_app(environ, start_response)
File "/usr/local/lib/python2.7/dist-packages/flask/app.py", line 2295, in wsgi_app
response = self.handle_exception(e)
File "/usr/local/lib/python2.7/dist-packages/flask/app.py", line 1741, in handle_exception
reraise(exc_type, exc_value, tb)
File "/usr/local/lib/python2.7/dist-packages/flask/app.py", line 2292, in wsgi_app
response = self.full_dispatch_request()
File "/usr/local/lib/python2.7/dist-packages/flask/app.py", line 1815, in full_dispatch_request
rv = self.handle_user_exception(e)
File "/usr/local/lib/python2.7/dist-packages/flask/app.py", line 1718, in handle_user_exception
reraise(exc_type, exc_value, tb)
File "/usr/local/lib/python2.7/dist-packages/flask/app.py", line 1813, in full_dispatch_request
rv = self.dispatch_request()
File "/usr/local/lib/python2.7/dist-packages/flask/app.py", line 1799, in dispatch_request
return self.view_functions[rule.endpoint](**req.view_args)
File "/vagrant/project.py", line 41, in showRestaurants
return render_template('restaurants.html', restaurants = restaurants)
File "/usr/local/lib/python2.7/dist-packages/flask/templating.py", line 135, in render_template
context, ctx.app)
File "/usr/local/lib/python2.7/dist-packages/flask/templating.py", line 117, in _render
rv = template.render(context)
File "/usr/local/lib/python2.7/dist-packages/jinja2/environment.py", line 1008, in render
return self.environment.handle_exception(exc_info, True)
File "/usr/local/lib/python2.7/dist-packages/jinja2/environment.py", line 780, in handle_exception
reraise(exc_type, exc_value, tb)
File "/vagrant/templates/restaurants.html", line 1, in top-level template code
{% extends "main.html" %}
File "/vagrant/templates/main.html", line 10, in top-level template code
{% block content %}
File "/vagrant/templates/restaurants.html", line 44, in block "content"
{% for restaurant in restaurants %}
File "/usr/lib/python2.7/dist-packages/sqlalchemy/orm/query.py", line 2736, in __iter__
return self._execute_and_instances(context)
```


I fixed that by setting **check_same_thread** to **False** when making the connection to the database, so the connection may be shared between multiple thread. 